### PR TITLE
use file extension from database when it exists and the file on disk has no extension

### DIFF
--- a/pydb/fileserver.py
+++ b/pydb/fileserver.py
@@ -95,6 +95,11 @@ class FileServer(object):
                 logger.warning(u"Could not strip file {}, seems to be broken".format(source_path))
                 return None, None, None
 
+        if len(extension) == 0:
+            existing_extension = self.db.get_file_extension(file_hash)
+            if existing_extension is not None:
+                extension = existing_extension
+
         size = self.file_store.add_file(source_path, file_hash, extension, move_file)
         local_file_id = self.db.add_local_file_exists(file_hash, extension)
 

--- a/pydb/testing/integration_tests/test_file_server.py
+++ b/pydb/testing/integration_tests/test_file_server.py
@@ -51,6 +51,13 @@ class TestFileServer(unittest.TestCase):
         self.file_server.delete_file(file_hash)
         self.assertFalse(self.file_server.is_file_in_store(self.test_epub_path, 'epub'))
 
+    def test_after_re_adding_an_existing_file_without_extension_no_new_entry_is_created(self):
+        txt_file_without_extension = get_book_path('pg1661_txt')
+        first_id, first_hash, first_size = self.file_server.add_file_from_local_disk(self.test_txt_path, 'txt')
+        second_id,  second_hash, second_size = self.file_server.add_file_from_local_disk(txt_file_without_extension, '')
+        self.assertEqual(first_id, second_id)
+
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/pydb/testing/test_data/books/pg1661_txt
+++ b/pydb/testing/test_data/books/pg1661_txt
@@ -1,0 +1,1 @@
+This is "The Adventures of Sherlock Holmes" by Arthur Conan Doyle from project Gutenberg: http://www.gutenberg.org/ebooks/1661


### PR DESCRIPTION
use file extension from database when it exists and the file on disk has no extension