### PR TITLE
Add build-essential to prerequisites

### DIFF
--- a/docs/INSTALL_BANANAPI.md
+++ b/docs/INSTALL_BANANAPI.md
@@ -20,6 +20,7 @@ Boot, log in and execute the following commands:
         sudo apt-get update
         sudo apt-get install git python-pip python-virtualenv
         sudo apt-get install libz-dev python-dev
+        sudo apt-get install build-essential
         git clone https://github.com/montaggroup/montag.git
         cd montag
         virtualenv venv


### PR DESCRIPTION
This is necessary in order to install the pip requirements. Otherwise, it will fail with something like:

```
    unable to execute 'arm-linux-gnueabihf-gcc': No such file or directory
    error: command 'arm-linux-gnueabihf-gcc' failed with exit status 1

    ----------------------------------------
Command "/home/vnz/.virtualenvs/montag/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-O6ymoL/Twisted/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-u_2Oyx-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/vnz/.virtualenvs/montag/include/site/python2.7/Twisted" failed with error code 1 in /tmp/pip-build-O6ymoL/Twisted/
```